### PR TITLE
Fix Meerkat-based parser and improve benchmarking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,3 +7,5 @@ libraryDependencies ++= Seq(
   "org.meerkat" %% "meerkat" % "0.1.0",
   "org.bitbucket.inkytonik.dsinfo" %% "dsinfo" % "0.4.0"
 )
+
+fork := true

--- a/src/main/scala/MeerkatJSONParser.scala
+++ b/src/main/scala/MeerkatJSONParser.scala
@@ -4,7 +4,7 @@ import org.meerkat.parsers._
 import Parsers._
 
 class MeerkatJSONParser{
-  val num: Nonterminal = syn("[0-9]".r)
+  val num: Nonterminal = syn("[0-9]+".r)
   val str: Nonterminal = syn("\"[^\"]*\"".r)
   val `null`: Nonterminal = syn("null")
   val bool: Nonterminal = syn("true" | "false")


### PR DESCRIPTION
Each benchmark is run on demand (to isolate JVM warm-ups). So, benchmark for a parser is now run via `run PARSER_NAME` under the SBT shell. E.g., `run meerkat` for the Meerkat-based parser.